### PR TITLE
Get max local version instead of the first version in the dir

### DIFF
--- a/library/src/main/java/com/absinthe/rulesbundle/Repositories.kt
+++ b/library/src/main/java/com/absinthe/rulesbundle/Repositories.kt
@@ -20,8 +20,8 @@ object Repositories {
         val localCloudVersionFile = File(context.filesDir, LOCAL_RULES_VERSION_FILE)
         if (localCloudVersionFile.exists().not()) return LCRules.getVersion()
         if (localCloudVersionFile.isDirectory.not()) return LCRules.getVersion()
-        localCloudVersionFile.listFiles()?.takeIf { it.isNotEmpty() }?.let {
-            return runCatching { it[0].name.toInt() }.getOrDefault(LCRules.getVersion())
+        localCloudVersionFile.listFiles()?.takeIf { it.isNotEmpty() }?.let { files ->
+            return runCatching { files.maxOf { it.name.toInt() } }.getOrDefault(LCRules.getVersion())
         } ?: return LCRules.getVersion()
     }
 
@@ -54,8 +54,8 @@ object Repositories {
         val versionFile = File(context.filesDir, LOCAL_RULES_VERSION_FILE)
         if (versionFile.exists().not()) return false
         if (versionFile.isDirectory.not()) return false
-        versionFile.listFiles()?.takeIf { it.isNotEmpty() }?.let {
-            val version = runCatching { it[0].name.toInt() }.getOrDefault(0)
+        versionFile.listFiles()?.takeIf { it.isNotEmpty() }?.let { files ->
+            val version = runCatching { files.maxOf { it.name.toInt() } }.getOrDefault(0)
             return version >= LCRules.getVersion()
         } ?: return false
     }


### PR DESCRIPTION
Fix LibChecker/LibChecker#1037

https://github.com/LibChecker/LibChecker-Rules-Bundle/blob/065546738e614107c3a3aa8661044bc9918269dd/library/src/main/java/com/absinthe/rulesbundle/Repositories.kt#L28-L33

We'll add new version to the directory, but we don't remove the past versions. 

https://github.com/LibChecker/LibChecker-Rules-Bundle/blob/065546738e614107c3a3aa8661044bc9918269dd/library/src/main/java/com/absinthe/rulesbundle/Repositories.kt#L23-L25

And we just get the first version in the directory which should be the most outdated.

We should return the latest version in the directory by finding the max version code in the directory.